### PR TITLE
change select to use word-wrap normal

### DIFF
--- a/core/sass/formplate/_select.scss
+++ b/core/sass/formplate/_select.scss
@@ -62,6 +62,7 @@
 			@include text-size(14px);
 			text-transform: none;
 			word-spacing: normal;
+			word-wrap: normal;
 			outline: none;
 			-webkit-user-select: text;
 			-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Hey, I noticed when looking at using your lovely webplate that my selects were looking funky if they had long strings, or the container was small... check out the screenshots below.

I added word-wrap to help fix this.
### Before

![select-before](https://cloud.githubusercontent.com/assets/2817396/4475615/5a9e96d2-496e-11e4-801d-5e9ae1e6122e.PNG)
### After (using `word-wrap: normal;`)

![select-after](https://cloud.githubusercontent.com/assets/2817396/4475617/5c12855a-496e-11e4-8c0b-f453eac4fb65.PNG)
