### PR TITLE
docs: Fix simple typo, sytax -> syntax

### DIFF
--- a/project/component/injectplate/README.md
+++ b/project/component/injectplate/README.md
@@ -1,5 +1,5 @@
 # Injectplate
-A declare once Javascript component injector. This allows you to create HTML components and inject them into the DOM at will. In essence it is a wrapper for the awesome [Mustache.js](https://github.com/janl/mustache.js) library which has a great template sytax.
+A declare once Javascript component injector. This allows you to create HTML components and inject them into the DOM at will. In essence it is a wrapper for the awesome [Mustache.js](https://github.com/janl/mustache.js) library which has a great template syntax.
 
 ## Table of Contents
 


### PR DESCRIPTION
There is a small typo in project/component/injectplate/README.md.

Should read `syntax` rather than `sytax`.

